### PR TITLE
Shorter header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-#Resource-Freshness#
+#Freshness#
 Proposal for a HTTP header field to be used in the context of stale-while-revalidate (RFC5861)
 
 ##Background##
 For context, please read [Mark Nottingham's blog post about stale-while-revalidate](https://www.mnot.net/blog/2007/12/12/stale).
 
 ##Description of the header##
-Resource-Freshness is a HTTP header that user agents would send on revalidation of assets that were served with 
+Freshness is a HTTP header that user agents would send on revalidation of assets that were served with 
 the stale-while-revalidate Cache-Control directive.
 
 The purpose of this header is to help webmasters optimize the values of max-age and stale-while-revalidate for a given
 resource.
 
-The Resource-Freshness header will report the original max-age value, the original stale-while-revalidate value as well
+The Freshness header will report the original max-age value, the original stale-while-revalidate value as well
 as the current age of the asset.
 
 Example: 
- * Resource-Freshness: max-age=86400; stale-while-revalidate=259200; age= 103680
+ * Freshness: max-age=86400, stale-while-revalidate=259200, age=103680
 
 ##How the header would be used##
-Based on the information carried by Resource-Freshness, webmasters would be able to know how often user agents had to resort to synchronous
+Based on the information carried by Freshness, webmasters would be able to know how often user agents had to resort to synchronous
 revalidations and how bad the problem is. 
 
 For instance, revalidations could be categorized into asynchronous and synchronous by looking at the following instances:

--- a/permanent-template.txt
+++ b/permanent-template.txt
@@ -1,6 +1,6 @@
 PERMANENT MESSAGE HEADER FIELD REGISTRATION TEMPLATE:
 
-   Header field name: Resource-Freshness
+   Header field name: Freshness
 
    Applicable protocol: http
 

--- a/provisional-template.txt
+++ b/provisional-template.txt
@@ -1,6 +1,6 @@
 PROVISIONAL MESSAGE HEADER FIELD SUBMISSION TEMPLATE:
 
-   Header field name: Resource-Freshness
+   Header field name: Freshness
 
    Applicable protocol: http
 

--- a/specification.txt
+++ b/specification.txt
@@ -56,7 +56,7 @@ Status of This Memo
    was served with a stale-while-revalidate Cache-Control extension, it SHOULD
    include a Resource-Freshness header to its revalidation request.
 
-     Resource-Freshness = "Resource-Freshness" ":" max-age "," 
+     Resource-Freshness = "Freshness" ":" max-age "," 
        stale-while-revalidate ","
        age
     
@@ -106,7 +106,7 @@ Status of This Memo
    stale (640 > 600 + 30), a synchronous revalidation request is sent with the
    following header:
    
-     Resource-Freshness: max-age=600, stale-while-revalidate=30, age=640
+     Freshness: max-age=600, stale-while-revalidate=30, age=640
      
    The server would then know that the resource was originally served with a
    max-age Cache-Control extension of 600 seconds and a stale-while-revalidate
@@ -120,12 +120,12 @@ Status of This Memo
 
    This section is non-normative.
 
-   The Resource-Freshness header could be combined with other functionality in
+   The Freshness header could be combined with other functionality in
    order to identify a user through fingerprinting. Specifically, max-age and
    stale-while-revalidate could be set to peculiar values that may provide
    additional entropy.
    
-   Implementations may reduce the risk by not sending Resource-Freshness headers
+   Implementations may reduce the risk by not sending Freshness headers
    to web origins for which cookies have been blocked.
    
 


### PR DESCRIPTION
Resource-Freshness => Freshness
Also fixed use of incorrect delimiter in the readme.
